### PR TITLE
Stop DefaultLinkWidget from rerendering most of the time for performa…

### DIFF
--- a/src/DiagramEngine.ts
+++ b/src/DiagramEngine.ts
@@ -142,6 +142,14 @@ export class DiagramEngine extends BaseEntity<DiagramEngineListener> {
 		return this.paintableWidgets[baseModel.getID()] !== undefined;
 	}
 
+	canEntityRepaintStrict(baseModel: BaseModel<BaseEntity, BaseModelListener>) {
+		if (this.paintableWidgets === null) {
+			return false;
+		}
+
+		return this.paintableWidgets[baseModel.getID()] !== undefined;
+	}
+
 	setCanvas(canvas: Element | null) {
 		this.canvas = canvas;
 	}

--- a/src/defaults/widgets/DefaultLinkWidget.tsx
+++ b/src/defaults/widgets/DefaultLinkWidget.tsx
@@ -52,6 +52,19 @@ export class DefaultLinkWidget extends BaseWidget<DefaultLinkProps, DefaultLinkS
 		}
 	}
 
+	shouldComponentUpdate(nextProps: DefaultLinkProps, nextState: DefaultLinkState) {
+		// Most of the time, we don't need to redraw links.  We make allowances for three special cases:
+		// Link is being selected or unselected.
+		// We are creating a new link and dragging it around.
+		// We are moving an item, and its nearby links need to change
+		//   - This case is covered by canEntityRepaintStrict. MoveItemActions allows the nearby links to repaint.
+		return (
+			this.state.selected != nextState.selected ||
+			nextProps.link.extras.isNewLink == true ||
+			nextProps.diagramEngine.canEntityRepaintStrict(nextProps.link)
+		);
+	}
+
 	calculateAllLabelPosition() {
 		_.forEach(this.props.link.labels, (label, index) => {
 			this.calculateLabelPosition(label, index + 1);

--- a/src/models/LinkModel.ts
+++ b/src/models/LinkModel.ts
@@ -18,7 +18,7 @@ export class LinkModel<T extends LinkModelListener = LinkModelListener> extends 
 	targetPort: PortModel | null;
 	labels: LabelModel[];
 	points: PointModel[];
-	extras: {};
+	extras: { [key: string]: any };
 
 	constructor(linkType: string = "default", id?: string) {
 		super(linkType, id);

--- a/src/widgets/DiagramWidget.tsx
+++ b/src/widgets/DiagramWidget.tsx
@@ -342,6 +342,7 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 							link.removePointsBefore(model.model);
 						}
 					} else {
+						link.extras.isNewLink = false;
 						link.setTargetPort(element.model);
 					}
 					delete this.props.diagramEngine.linksThatHaveInitiallyRendered[link.getID()];
@@ -507,6 +508,7 @@ export class DiagramWidget extends BaseWidget<DiagramProps, DiagramState> {
 									link.setSourcePort(sourcePort);
 								}
 								link.setTargetPort(null);
+								link.extras.isNewLink = true;
 
 								link.getFirstPoint().updateLocation(relative);
 								link.getLastPoint().updateLocation(relative);


### PR DESCRIPTION
…nce reasons.

Most of the time, we don't need to redraw links.  We make allowances for three special cases:
 - Link is being selected or unselected.
 - We are creating a new link and dragging it around.
 - We are moving an item, and its nearby links need to change
   - This case is covered by canEntityRepaintStrict. MoveItemActions allows the nearby links to repaint.

